### PR TITLE
feat: update the shuffle function

### DIFF
--- a/src/components/project.tsx
+++ b/src/components/project.tsx
@@ -12,13 +12,15 @@ const cards: Record<
   CardType,
   ({ content }: { content: string }) => JSX.Element
 > = {
-  0: ({ content }) => (
+  [CardType.TEXT]: ({ content }) => (
     <div className="span-w-1 aspect-card">
       <p className="text-justify text">{content}</p>
     </div>
   ),
-  1: ({ content }) => <Image src={content} className="span-w-1 aspect-card" />,
-  2: () => <div className="span-w-1 aspect-card" />
+  [CardType.IMAGE]: ({ content }) => (
+    <Image src={content} className="span-w-1 aspect-card" />
+  ),
+  [CardType.EMPTY]: () => <div className="span-w-1 aspect-card" />
 }
 
 export const Project: React.FC<Props> = ({ data }) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,9 +27,9 @@ export interface DataType {
 }
 
 export enum CardType {
-  "TEXT",
-  "IMAGE",
-  "EMPTY"
+  TEXT = "TEXT",
+  IMAGE = "IMAGE",
+  EMPTY = "EMPTY"
 }
 
 export interface Colors {

--- a/src/utils/shuffle.ts
+++ b/src/utils/shuffle.ts
@@ -1,6 +1,115 @@
 import { CardType, WorkType } from "@/types"
 
-export const shuffle = ({ images, description }: WorkType) => {
+interface Content {
+  type: CardType
+  content: string
+}
+
+const getValidContentForIdx = (
+  idx: number,
+  contents: Content[],
+  textBeenUsed: boolean,
+  remainingImages: number
+) => {
+  const validContent: Record<CardType, boolean> = {
+    [CardType.EMPTY]: true,
+    [CardType.IMAGE]: true,
+    [CardType.TEXT]: true
+  }
+
+  // First card can be anything
+  if (idx === 0) return validContent
+
+  // Text already been added so not valid anymore
+  if (textBeenUsed) validContent[CardType.TEXT] = false
+
+  if (remainingImages === 0) validContent[CardType.IMAGE] = false
+
+  // If the previous card is EMPTY, the current card cannot be EMPTY
+  if (contents[idx - 1].type === CardType.EMPTY)
+    validContent[CardType.EMPTY] = false
+
+  // If before last card and text not yet added, force it to
+  if (!textBeenUsed && idx === contents.length - 2) {
+    validContent[CardType.EMPTY] = false
+    validContent[CardType.IMAGE] = false
+    return validContent
+  }
+
+  // Prevent adding empty card while remaning empty cards equal remaning unused images
+  if (contents.length - idx === remainingImages)
+    validContent[CardType.EMPTY] = false
+
+  // Save last image to prevent having text then empty at the end
+  if (idx === contents.length - 3 && !textBeenUsed && remainingImages === 1)
+    validContent[CardType.IMAGE] = false
+
+  // Remaining cards are only enough for remaining images and text card
+  if (contents.length - idx === remainingImages + 1 && !textBeenUsed)
+    validContent[CardType.EMPTY] = false
+
+  // if last card and ->
+  if (idx === contents.length - 1)
+    if (contents[idx - 1].type === CardType.TEXT)
+      // previous card was TEXT, current card can't be EMPTY
+      validContent[CardType.EMPTY] = false
+
+  return validContent
+}
+
+const shuffle = ({ images, description }: WorkType) => {
+  const targetLength = 7
+
+  const content: Content[] = new Array(targetLength).fill({
+    type: CardType.EMPTY,
+    content: ""
+  })
+
+  const remainingImages = [...images]
+  let textBeenUsed = false
+
+  for (let i = 0; i < targetLength; i++) {
+    const validContent = getValidContentForIdx(
+      i,
+      content,
+      textBeenUsed,
+      remainingImages.length
+    )
+
+    const _validTypes = Object.entries(validContent)
+      .filter(([_, valid]) => valid)
+      .map(([type]) => type as CardType)
+
+    const validTypes = [..._validTypes, ..._validTypes] // Double the odds I guess ?
+
+    const randomType = validTypes[getRandomNumber(validTypes.length)]
+    if (randomType === CardType.TEXT) {
+      textBeenUsed = true
+      content[i] = {
+        type: CardType.TEXT,
+        content: description
+      }
+    }
+
+    if (randomType === CardType.IMAGE) {
+      const randomIndex = getRandomNumber(remainingImages.length)
+      content[i] = {
+        type: CardType.IMAGE,
+        content: remainingImages[randomIndex]
+      }
+      remainingImages.splice(randomIndex, 1)
+    }
+  }
+
+  return content
+}
+
+const getRandomNumber = (max: number) => {
+  return Math.floor(Math.random() * max)
+}
+
+// OLD SHUFFLE
+const oldShuffle = ({ images, description }: WorkType) => {
   const contents = images.map((image) => ({
     type: CardType.IMAGE,
     content: image
@@ -93,3 +202,5 @@ export const shuffle = ({ images, description }: WorkType) => {
   )
   return shuffled // Return the last shuffled array, even if invalid, to prevent infinite loops.
 }
+
+export { shuffle as shuffle }


### PR DESCRIPTION
Updated the shuffle function to remove looping 1000 time until finding a valid shuffle.

The new function basically return the valid possible options for the current card, then pick a random one for the returned valid options. Its as hardcoded as an online gambling random function can get, but will get your a valid shuffle in a O(1).

PS: I opened the pr to implementation so you don't see 30+ files changes just my commit, once implementation is merged to devel I'll change the pr base  branch.